### PR TITLE
Make order-preserving unique faster

### DIFF
--- a/blazeutils/helpers.py
+++ b/blazeutils/helpers.py
@@ -142,7 +142,8 @@ def unique(seq, preserve_order=True):
         # f8 by Dave Kirby
         # Order preserving
         seen = set()
-        return [x for x in seq if x not in seen and not seen.add(x)]
+        seen_add = seen.add  # lookup method only once
+        return [x for x in seq if x not in seen and not seen_add(x)]
     # f9
     # Not order preserving
     return list({}.fromkeys(seq).keys())


### PR DESCRIPTION
Taking a suggestion from StackOverflow...

This shaves off 12% overhead and is the fastest known implementation in Python.
